### PR TITLE
fix: Revert secure mode

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -20,7 +20,7 @@ type Config struct {
 		KeyFile           string `envconfig:"SERVER_KEY_FILE" default:"/tmp/certs/server-key.pem"`   // Server key PEM file
 		CACertFile        string `envconfig:"CLIENT_CERT_FILE" default:"/tmp/certs/ca-cert.pem"`     // CA certificate file
 		SkipPrepareServer bool   `envconfig:"SKIP_PREPARE_SERVER" default:"false"`                   // skip prepare server, install docker / git
-		Insecure          bool   `envconfig:"SERVER_INSECURE" default:"false"`                       // run in insecure mode
+		Insecure          bool   `envconfig:"SERVER_INSECURE" default:"true"`                        // run in insecure mode
 	}
 
 	Client struct {
@@ -28,7 +28,7 @@ type Config struct {
 		CertFile   string `envconfig:"CLIENT_CERT_FILE" default:"/tmp/certs/server-cert.pem"` // Server certificate PEM file
 		KeyFile    string `envconfig:"CLIENT_KEY_FILE" default:"/tmp/certs/server-key.pem"`   // Server Key PEM file
 		CaCertFile string `envconfig:"CA_CERT_FILE" default:"/tmp/certs/ca-cert.pem"`         // CA certificate file
-		Insecure   bool   `envconfig:"CLIENT_INSECURE" default:"false"`                       // dont check server certificate
+		Insecure   bool   `envconfig:"CLIENT_INSECURE" default:"true"`                        // don't check server certificate
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -31,8 +31,8 @@ type Server struct {
 
 // Start initializes a server to respond to HTTPS/TLS network requests.
 func (s *Server) Start(ctx context.Context) error {
-	// Uncomment the following line for local run
-	// s.Insecure = true
+	// The default run mode is insecure, as most clients will run the delegate and
+	// the docker runner on a same host.
 
 	logrus.Infof("Runner version: %s", version.Version)
 
@@ -65,9 +65,8 @@ func (s *Server) Start(ctx context.Context) error {
 
 	var g errgroup.Group
 	g.Go(func() error {
-		// Uncomment the following line for local run
-		// s.Insecure = true
-
+		// The default run mode is insecure, as most clients will run the delegate and
+		// the docker runner on a same host.
 		if s.Insecure {
 			return srv.ListenAndServe()
 		}


### PR DESCRIPTION
We want to keep the default run in insecure mode, as most clients will run docker runner and delegate in a same host.