### PR TITLE
Changed path delimiter to semicolon

### DIFF
--- a/handler/setup.go
+++ b/handler/setup.go
@@ -217,7 +217,7 @@ func getGlobalVolumes(config *config.Config) []*spec.Volume {
 
 func parseVolume(runnerVolume string) (volume *spec.Volume, err error) {
 
-	z := strings.SplitN(runnerVolume, ":", 2)
+	z := strings.SplitN(runnerVolume, ";", 2)
 	if len(z) != 2 {
 		return volume, fmt.Errorf("volume %s is not in the format src:dest", runnerVolume)
 	}

--- a/handler/step.go
+++ b/handler/step.go
@@ -127,7 +127,7 @@ func getGlobalVolumesMount(config *config.Config) []*spec.VolumeMount {
 }
 
 func parseVolumeMount(runnerVolume string) (volume *spec.VolumeMount, err error) {
-	z := strings.SplitN(runnerVolume, ":", 2)
+	z := strings.SplitN(runnerVolume, ";", 2)
 	if len(z) != 2 {
 		return volume, fmt.Errorf("volume %s is not in the format src:dest", runnerVolume)
 	}


### PR DESCRIPTION
Earlier it was a colon (:). Since windows path can have a colon (C://blah) we have switched to use semicolon instead.