### PR TITLE
feat: [IAC-1301]: Support for dynamic output vars via DRONE_OUTPUT

### DIFF
--- a/pipeline/runtime/common.go
+++ b/pipeline/runtime/common.go
@@ -88,6 +88,12 @@ func fetchOutputVariables(outputFile string, out io.Writer) (map[string]string, 
 	log.Out = out
 
 	outputs := make(map[string]string)
+
+	// The output file maybe not exist - we don't consider that an error
+	if _, err := os.Stat(outputFile); os.IsNotExist(err) {
+		return outputs, nil
+	}
+
 	f, err := os.Open(outputFile)
 	if err != nil {
 		log.WithError(err).WithField("outputFile", outputFile).Errorln("failed to open output file")


### PR DESCRIPTION
Lite-engine introduced support for "dynamic" output variables i.e. output variables that are not known about ahead of time. For example, IACM uses this functionality to return output variables from your Terraform "plan" step.

That work can be found here:
* https://github.com/harness/lite-engine/pull/123 << mainly this one
* https://github.com/harness/lite-engine/pull/124 << smaller updates
* https://github.com/harness/lite-engine/pull/126 << smaller updates

The corresponding changes were not made in this repo, meaning steps executing with this runner do not see the expected outputs.

This commit adds support for DRONE_OUTPUT and changes the logic around reading output variables to match that found in lite-engine.