### PR TITLE
fix: [CI-12532]: Make destroy async so upstream service should not be blocking

### DIFF
--- a/handler/destroy.go
+++ b/handler/destroy.go
@@ -5,6 +5,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -74,7 +75,7 @@ func handleDestroyInternal(r *http.Request, s api.DestroyRequest) error {
 	}
 	if d != nil {
 		logger.FromRequest(r).WithField("id", s.ID).Traceln("starting the destroy process")
-		if err := d.Engine.Destroy(r.Context()); err != nil {
+		if err := d.Engine.Destroy(context.Background()); err != nil {
 			return err
 		} else {
 			ex.Remove(s.ID)

--- a/handler/destroy.go
+++ b/handler/destroy.go
@@ -7,20 +7,23 @@ package handler
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
-	"github.com/harness/harness-docker-runner/executor"
-
+	"github.com/cenkalti/backoff/v4"
 	"github.com/harness/harness-docker-runner/api"
+	"github.com/harness/harness-docker-runner/executor"
 	"github.com/harness/harness-docker-runner/logger"
+)
+
+const (
+	destroyTimeout = 10 * time.Minute
 )
 
 // HandleDestroy returns an http.HandlerFunc that destroy the stage resources
 func HandleDestroy() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		st := time.Now()
-
 		var s api.DestroyRequest
 		err := json.NewDecoder(r.Body).Decode(&s)
 		if err != nil {
@@ -34,27 +37,58 @@ func HandleDestroy() http.HandlerFunc {
 			return
 		}
 
-		ex := executor.GetExecutor()
-		d, err := ex.Get(s.ID)
+		go func(r *http.Request, s api.DestroyRequest) {
+			b := createBackoff(destroyTimeout)
+			cnt := 0
+			var lastErr error
 
-		if err != nil {
-			logger.FromRequest(r).WithError(err).WithField("id", s.ID).Errorln("stage mapping does not exist")
-			WriteNotFound(w, err)
-			return
-		}
+			for {
+				duration := b.NextBackOff()
+				<-time.After(duration)
 
-		if d != nil {
-			logger.FromRequest(r).WithField("id", s.ID).Traceln("starting the destroy process")
-			if err := d.Engine.Destroy(r.Context()); err != nil {
-				WriteError(w, err)
-			} else {
-				ex.Remove(s.ID)
-				logger.FromRequest(r).
-					WithField("latency", time.Since(st)).
-					WithField("time", time.Now().Format(time.RFC3339)).
-					Infoln("api: successfully destroyed the stage resources")
-				WriteJSON(w, api.DestroyResponse{}, http.StatusOK)
+				if err := handleDestroyInternal(r, s); err != nil {
+					if duration == backoff.Stop {
+						logger.FromRequest(r).WithField("id", s.ID).WithError(err).Errorln("could not cleanup resources")
+						return
+					}
+					if lastErr == nil || lastErr.Error() != err.Error() {
+						logger.FromRequest(r).WithField("id", s.ID).WithError(err).Errorln("could not cleanup resources, retry count ", cnt)
+						lastErr = err
+					}
+					cnt++
+					continue
+				}
+				return
 			}
+		}(r, s)
+		WriteJSON(w, api.DestroyResponse{}, http.StatusOK)
+	}
+}
+
+func handleDestroyInternal(r *http.Request, s api.DestroyRequest) error {
+	st := time.Now()
+	ex := executor.GetExecutor()
+	d, err := ex.Get(s.ID)
+	if err != nil {
+		return fmt.Errorf("stage mapping does not exist")
+	}
+	if d != nil {
+		logger.FromRequest(r).WithField("id", s.ID).Traceln("starting the destroy process")
+		if err := d.Engine.Destroy(r.Context()); err != nil {
+			return err
+		} else {
+			ex.Remove(s.ID)
+			logger.FromRequest(r).
+				WithField("latency", time.Since(st)).
+				WithField("time", time.Now().Format(time.RFC3339)).
+				Infoln("api: successfully destroyed the stage resources")
 		}
 	}
+	return nil
+}
+
+func createBackoff(maxElapsedTime time.Duration) *backoff.ExponentialBackOff {
+	exp := backoff.NewExponentialBackOff()
+	exp.MaxElapsedTime = maxElapsedTime
+	return exp
 }

--- a/handler/destroy.go
+++ b/handler/destroy.go
@@ -48,7 +48,7 @@ func HandleDestroy() http.HandlerFunc {
 
 				if err := handleDestroyInternal(r, s); err != nil {
 					if duration == backoff.Stop {
-						logger.FromRequest(r).WithField("id", s.ID).WithError(err).Errorln("could not cleanup resources")
+						logger.FromRequest(r).WithField("id", s.ID).WithError(err).Errorln("Failed to destroy resources")
 						return
 					}
 					if lastErr == nil || lastErr.Error() != err.Error() {


### PR DESCRIPTION
Added change to make the destroy call async so the upstream service is not blocking.