### PR TITLE
[feat]: [CI-12484]: Add support for RunTestsV2

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -23,9 +23,10 @@ const (
 )
 
 type (
-	RunTestConfig = leapi.RunTestConfig
-	TestReport    = leapi.TestReport
-	TIConfig      = leapi.TIConfig
+	RunTestConfig    = leapi.RunTestConfig
+	RunTestsV2Config = leapi.RunTestsV2Config
+	TestReport       = leapi.TestReport
+	TIConfig         = leapi.TIConfig
 )
 
 type (
@@ -92,6 +93,7 @@ type (
 		Kind       StepType          `json:"kind,omitempty"`
 		Run        RunConfig         `json:"run,omitempty"`
 		RunTest    RunTestConfig     `json:"run_test,omitempty"`
+		RunTestsV2 RunTestsV2Config  `json:"run_test_v2,omitempty"`
 
 		OutputVars        []string    `json:"output_vars,omitempty"`
 		TestReport        TestReport  `json:"test_report,omitempty"`

--- a/api/step_type.go
+++ b/api/step_type.go
@@ -16,6 +16,7 @@ type StepType int
 const (
 	Run StepType = iota
 	RunTest
+	RunTestsV2
 )
 
 func (s StepType) String() string {
@@ -23,14 +24,16 @@ func (s StepType) String() string {
 }
 
 var stepTypeID = map[StepType]string{
-	Run:     "Run",
-	RunTest: "RunTest",
+	Run:        "Run",
+	RunTest:    "RunTest",
+	RunTestsV2: "RunTestsV2",
 }
 
 var stepTypeName = map[string]StepType{
-	"":        Run,
-	"Run":     Run,
-	"RunTest": RunTest,
+	"":           Run,
+	"Run":        Run,
+	"RunTest":    RunTest,
+	"RunTestsV2": RunTestsV2,
 }
 
 // MarshalJSON marshals the string representation of the

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/google/gops v0.3.25 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/harness/godotenv/v2 v2.0.0 // indirect
-	github.com/harness/lite-engine v0.5.77 // indirect
+	github.com/harness/lite-engine v0.5.78 // indirect
 	github.com/harness/ti-client v0.0.0-20240617230757-1e90e7e3ada2 // indirect
 	github.com/keybase/go-ps v0.0.0-20190827175125-91aafc93ba19 // indirect
 	github.com/klauspost/compress v1.16.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -574,8 +574,8 @@ github.com/harness/godotenv/v2 v2.0.0 h1:9Hpa8PfXQ5PJ8kGmSLp4eEdPLhVXsUMGMHrH7yo
 github.com/harness/godotenv/v2 v2.0.0/go.mod h1:f2Xdq/sKp6M464DNmLny9JhQIrPPp2yRlha9q78ZhAs=
 github.com/harness/godotenv/v3 v3.0.0 h1:1YJU9nUk4tQygHOYkm+NZ5jL9IZQ3UqyBspCqL3EMQQ=
 github.com/harness/godotenv/v3 v3.0.0/go.mod h1:UIXXJtTM7NkSYMYknHYOO2d8BfDlAWMYZRuRsXcDDR0=
-github.com/harness/lite-engine v0.5.77 h1:poylnMlqswVQyQnFPNv11c6ffOoymDhK4nl63SjOvMY=
-github.com/harness/lite-engine v0.5.77/go.mod h1:07w13fj/1efZZgY78xBo+iXuZH3BiVIx44cNZkHKPlc=
+github.com/harness/lite-engine v0.5.78 h1:6EOIlW0djiJ7a9xgWppxu+FOUiXwZFYK59sbiRQ10lo=
+github.com/harness/lite-engine v0.5.78/go.mod h1:07w13fj/1efZZgY78xBo+iXuZH3BiVIx44cNZkHKPlc=
 github.com/harness/ti-client v0.0.0-20240617230757-1e90e7e3ada2 h1:9QHzlirx9Lg77ohXYTOeC+3aDPG8ZeHTKI1iAN5+cIo=
 github.com/harness/ti-client v0.0.0-20240617230757-1e90e7e3ada2/go.mod h1:/ow4f34mPgr5KPkzKxmBUB4cC09OjzStcLX6R8+43TI=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=

--- a/pipeline/runtime/runtestsV2.go
+++ b/pipeline/runtime/runtestsV2.go
@@ -1,0 +1,173 @@
+// Copyright 2022 Drone.IO Inc. All rights reserved.
+// Use of this source code is governed by the Polyform License
+// that can be found in the LICENSE file.
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/drone/runner-go/pipeline/runtime"
+	"github.com/sirupsen/logrus"
+
+	"github.com/harness/harness-docker-runner/api"
+	"github.com/harness/harness-docker-runner/engine"
+	"github.com/harness/harness-docker-runner/pipeline"
+	leRuntime "github.com/harness/lite-engine/pipeline/runtime"
+	"github.com/harness/lite-engine/ti/callgraph"
+	tiCfg "github.com/harness/lite-engine/ti/config"
+	"github.com/harness/lite-engine/ti/report"
+)
+
+func executeRunTestsV2Step(ctx context.Context, engine *engine.Engine, r *api.StartStepRequest, out io.Writer, tiConfig *tiCfg.Cfg) (
+	*runtime.State, map[string]string, []byte, []*api.OutputV2, error) {
+	log := logrus.New()
+	log.Out = out
+	step := toStep(r)
+	start := time.Now()
+	step.Entrypoint = r.RunTestsV2.Entrypoint
+	preCmd, err := leRuntime.SetupRunTestV2(ctx, &r.RunTestsV2, step.Name, r.WorkingDir, log, r.Envs, tiConfig)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	command := r.RunTestsV2.Command[0]
+	if preCmd != "" {
+		command = fmt.Sprintf("%s\n%s", preCmd, command)
+	}
+	step.Command = []string{command}
+
+	if (len(r.OutputVars) > 0 || len(r.Outputs) > 0) && (len(step.Entrypoint) == 0 || len(step.Command) == 0) {
+		return nil, nil, nil, nil, fmt.Errorf("output variable should not be set for unset entrypoint or command")
+	}
+
+	enablePluginOutputSecrets := IsFeatureFlagEnabled(ciEnablePluginOutputSecrets, engine, step)
+
+	var outputFile string
+
+	var outputSecretsFile string
+
+	if enablePluginOutputSecrets {
+		outputFile = fmt.Sprintf("%s/%s-output.env", pipeline.SharedVolPath, step.ID)
+		step.Envs["DRONE_OUTPUT"] = outputFile
+
+		outputSecretsFile = fmt.Sprintf("%s/%s-output-secrets.env", pipeline.SharedVolPath, step.ID)
+		step.Envs["HARNESS_OUTPUT_SECRET_FILE"] = outputSecretsFile
+	} else {
+		outputFile = fmt.Sprintf("%s/%s.out", pipeline.SharedVolPath, step.ID)
+		step.Envs["DRONE_OUTPUT"] = outputFile
+	}
+
+	if len(r.Outputs) > 0 {
+		step.Command[0] += getOutputsCmd(step.Entrypoint, r.Outputs, outputFile, enablePluginOutputSecrets)
+	} else if len(r.OutputVars) > 0 {
+		step.Command[0] += getOutputVarCmd(step.Entrypoint, r.OutputVars, outputFile, enablePluginOutputSecrets)
+	}
+
+	logrus.WithField("step_id", r.ID).WithField("stage_id", r.StageRuntimeID).Traceln("starting step run")
+
+	artifactFile := fmt.Sprintf("%s/%s-artifact", pipeline.SharedVolPath, step.ID)
+	step.Envs["PLUGIN_ARTIFACT_FILE"] = artifactFile
+
+	exited, err := engine.Run(ctx, step, out)
+	logrus.WithField("step_id", r.ID).WithField("stage_id", r.StageRuntimeID).Traceln("completed step run")
+	if rerr := report.ParseAndUploadTests(ctx, r.TestReport, r.WorkingDir, step.Name, log, time.Now(), tiConfig, r.Envs); rerr != nil {
+		log.WithError(rerr).Errorln("failed to upload report")
+	}
+
+	if uerr := callgraph.Upload(ctx, step.Name, time.Since(start).Milliseconds(), log, time.Now(), tiConfig, cgDir); uerr != nil {
+		log.WithError(uerr).Errorln("unable to collect callgraph")
+	}
+
+	artifact, _ := fetchArtifactDataFromArtifactFile(artifactFile, out)
+	if exited != nil && exited.Exited && exited.ExitCode == 0 {
+		if enablePluginOutputSecrets {
+			outputs, err := fetchExportedVarsFromEnvFile(outputFile, out)
+			outputsV2 := []*api.OutputV2{}
+			var finalErr error
+			if len(r.Outputs) > 0 {
+				// only return err when output vars are expected
+				finalErr = err
+				for _, output := range r.Outputs {
+					if _, ok := outputs[output.Key]; ok {
+						outputsV2 = append(outputsV2, &api.OutputV2{
+							Key:   output.Key,
+							Value: outputs[output.Key],
+							Type:  output.Type,
+						})
+					}
+				}
+			} else {
+				if len(r.OutputVars) > 0 {
+					// only return err when output vars are expected
+					finalErr = err
+				}
+				for key, value := range outputs {
+					output := &api.OutputV2{
+						Key:   key,
+						Value: value,
+						Type:  api.OutputTypeString,
+					}
+					outputsV2 = append(outputsV2, output)
+				}
+			}
+			// Delete output variable file
+			if _, err := os.Stat(outputFile); err == nil {
+				if ferr := os.Remove(outputFile); ferr != nil {
+					logrus.WithError(ferr).WithField("file", outputFile).Warnln("could not remove output file")
+				}
+			}
+
+			//checking exported secrets from plugins if any
+			if _, err := os.Stat(outputSecretsFile); err == nil {
+				secrets, err := fetchExportedVarsFromEnvFile(outputSecretsFile, out)
+				if err != nil {
+					log.WithError(err).Errorln("error encountered while fetching output secrets from env File")
+				}
+				for key, value := range secrets {
+					output := &api.OutputV2{
+						Key:   key,
+						Value: value,
+						Type:  api.OutputTypeSecret,
+					}
+					outputsV2 = append(outputsV2, output)
+				}
+				// Delete output secrets file
+				if ferr := os.Remove(outputSecretsFile); ferr != nil {
+					logrus.WithError(ferr).WithField("file", outputSecretsFile).Warnln("could not remove output secrets file")
+				}
+			}
+
+			return exited, outputs, artifact, outputsV2, finalErr
+
+		} else {
+			outputs, err := fetchOutputVariables(outputFile, out, false) // nolint:govet
+			if err != nil {
+				return exited, nil, nil, nil, err
+			}
+			// Delete output variable file
+			if ferr := os.Remove(outputFile); ferr != nil {
+				logrus.WithError(ferr).WithField("file", outputFile).Warnln("could not remove output file")
+			}
+			if len(r.Outputs) > 0 {
+				outputsV2 := []*api.OutputV2{}
+				for _, output := range r.Outputs {
+					if _, ok := outputs[output.Key]; ok {
+						outputsV2 = append(outputsV2, &api.OutputV2{
+							Key:   output.Key,
+							Value: outputs[output.Key],
+							Type:  output.Type,
+						})
+					}
+				}
+				return exited, outputs, artifact, outputsV2, err
+			}
+			return exited, outputs, artifact, nil, err
+		}
+	}
+
+	return exited, nil, artifact, nil, err
+}

--- a/pipeline/runtime/step_executor.go
+++ b/pipeline/runtime/step_executor.go
@@ -307,6 +307,9 @@ func (e *StepExecutor) run(ctx context.Context, engine *engine.Engine, r *api.St
 	if r.Kind == api.Run {
 		return executeRunStep(ctx, engine, r, out, tiConfig)
 	}
+	if r.Kind == api.RunTestsV2 {
+		return executeRunTestsV2Step(ctx, engine, r, out, tiConfig)
+	}
 	return executeRunTestStep(ctx, engine, r, out, tiConfig)
 }
 


### PR DESCRIPTION
This PR adds supports for RunTestV2 in Harness Docker Runner. 

Testing Done: 

Java
Full Run: https://app.harness.io/ng/account/9UuUfLwaQ-6ZowvbG7qtLQ/module/ci/orgs/default/projects/anuragworkspace/pipelines/JHTTP_Linux_Docker_Runner/executions/_O9I1ZoQTr-JVGJg_8K_yQ/pipeline?storeType=INLINE
TI Run: https://app.harness.io/ng/account/9UuUfLwaQ-6ZowvbG7qtLQ/module/ci/orgs/default/projects/anuragworkspace/pipelines/JHTTP_Linux_Docker_Runner/executions/y8Z2gBDJTx2s1Az38isM9g/pipeline?storeType=INLINE

Made sure precmd and env variables injected properly, test selection happens, cg gets uploaded and test reports get uploaded by default