### PR TITLE
feat: Add direct device passthrough support

### DIFF
--- a/engine/docker/convert.go
+++ b/engine/docker/convert.go
@@ -107,8 +107,10 @@ func toHostConfig(pipelineConfig *spec.PipelineConfig, step *spec.Step) *contain
 		}
 	}
 
-	if len(step.Volumes) != 0 {
+	if len(step.Devices) != 0 {
 		config.Devices = toDeviceSlice(pipelineConfig, step)
+	}
+	if len(step.Volumes) != 0 {
 		config.Binds = toVolumeSlice(pipelineConfig, step)
 		config.Mounts = toVolumeMounts(pipelineConfig, step)
 	}
@@ -200,6 +202,18 @@ func toNetConfig(pipelineConfig *spec.PipelineConfig, proc *spec.Step) *network.
 func toDeviceSlice(pipelineConfig *spec.PipelineConfig, step *spec.Step) []container.DeviceMapping {
 	var to []container.DeviceMapping
 	for _, mount := range step.Devices {
+		if mount.HostPath != "" {
+			containerPath := mount.DevicePath
+			if containerPath == "" {
+				containerPath = mount.HostPath
+			}
+			to = append(to, container.DeviceMapping{
+				PathOnHost:        mount.HostPath,
+				PathInContainer:   containerPath,
+				CgroupPermissions: "rwm",
+			})
+			continue
+		}
 		device, ok := lookupVolume(pipelineConfig, mount.Name)
 		if !ok {
 			continue

--- a/engine/docker/convert_test.go
+++ b/engine/docker/convert_test.go
@@ -1,0 +1,169 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/harness/harness-docker-runner/engine/spec"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToDeviceSlice(t *testing.T) {
+	tests := []struct {
+		name           string
+		pipelineConfig *spec.PipelineConfig
+		step           *spec.Step
+		expected       []container.DeviceMapping
+	}{
+		{
+			name:           "direct host_path device",
+			pipelineConfig: &spec.PipelineConfig{},
+			step: &spec.Step{
+				Devices: []*spec.VolumeDevice{
+					{HostPath: "/dev/kvm", DevicePath: "/dev/kvm"},
+				},
+			},
+			expected: []container.DeviceMapping{
+				{PathOnHost: "/dev/kvm", PathInContainer: "/dev/kvm", CgroupPermissions: "rwm"},
+			},
+		},
+		{
+			name:           "direct host_path with empty device_path defaults to host path",
+			pipelineConfig: &spec.PipelineConfig{},
+			step: &spec.Step{
+				Devices: []*spec.VolumeDevice{
+					{HostPath: "/dev/fuse"},
+				},
+			},
+			expected: []container.DeviceMapping{
+				{PathOnHost: "/dev/fuse", PathInContainer: "/dev/fuse", CgroupPermissions: "rwm"},
+			},
+		},
+		{
+			name: "legacy volume lookup path",
+			pipelineConfig: &spec.PipelineConfig{
+				Volumes: []*spec.Volume{
+					{
+						HostPath: &spec.VolumeHostPath{
+							Name: "my-device",
+							Path: "/dev/sda",
+						},
+					},
+				},
+			},
+			step: &spec.Step{
+				Devices: []*spec.VolumeDevice{
+					{Name: "my-device", DevicePath: "/dev/sda"},
+				},
+			},
+			expected: []container.DeviceMapping{
+				{PathOnHost: "/dev/sda", PathInContainer: "/dev/sda", CgroupPermissions: "rwm"},
+			},
+		},
+		{
+			name: "legacy lookup skips non-device volume",
+			pipelineConfig: &spec.PipelineConfig{
+				Volumes: []*spec.Volume{
+					{
+						HostPath: &spec.VolumeHostPath{
+							Name: "my-volume",
+							Path: "/tmp/data",
+						},
+					},
+				},
+			},
+			step: &spec.Step{
+				Devices: []*spec.VolumeDevice{
+					{Name: "my-volume", DevicePath: "/tmp/data"},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "legacy lookup with unknown name skipped",
+			pipelineConfig: &spec.PipelineConfig{
+				Volumes: []*spec.Volume{},
+			},
+			step: &spec.Step{
+				Devices: []*spec.VolumeDevice{
+					{Name: "nonexistent", DevicePath: "/dev/foo"},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "mixed direct and legacy devices",
+			pipelineConfig: &spec.PipelineConfig{
+				Volumes: []*spec.Volume{
+					{
+						HostPath: &spec.VolumeHostPath{
+							Name: "my-device",
+							Path: "/dev/sda",
+						},
+					},
+				},
+			},
+			step: &spec.Step{
+				Devices: []*spec.VolumeDevice{
+					{HostPath: "/dev/kvm"},
+					{Name: "my-device", DevicePath: "/dev/sda"},
+				},
+			},
+			expected: []container.DeviceMapping{
+				{PathOnHost: "/dev/kvm", PathInContainer: "/dev/kvm", CgroupPermissions: "rwm"},
+				{PathOnHost: "/dev/sda", PathInContainer: "/dev/sda", CgroupPermissions: "rwm"},
+			},
+		},
+		{
+			name:           "empty devices list returns nil",
+			pipelineConfig: &spec.PipelineConfig{},
+			step: &spec.Step{
+				Devices: []*spec.VolumeDevice{},
+			},
+			expected: nil,
+		},
+		{
+			name: "host_path takes priority over name",
+			pipelineConfig: &spec.PipelineConfig{
+				Volumes: []*spec.Volume{
+					{
+						HostPath: &spec.VolumeHostPath{
+							Name: "my-device",
+							Path: "/dev/sda",
+						},
+					},
+				},
+			},
+			step: &spec.Step{
+				Devices: []*spec.VolumeDevice{
+					{HostPath: "/dev/kvm", Name: "my-device", DevicePath: "/dev/sda"},
+				},
+			},
+			expected: []container.DeviceMapping{
+				{PathOnHost: "/dev/kvm", PathInContainer: "/dev/sda", CgroupPermissions: "rwm"},
+			},
+		},
+		{
+			name:           "multiple direct devices",
+			pipelineConfig: &spec.PipelineConfig{},
+			step: &spec.Step{
+				Devices: []*spec.VolumeDevice{
+					{HostPath: "/dev/kvm"},
+					{HostPath: "/dev/fuse"},
+					{HostPath: "/dev/net/tun"},
+				},
+			},
+			expected: []container.DeviceMapping{
+				{PathOnHost: "/dev/kvm", PathInContainer: "/dev/kvm", CgroupPermissions: "rwm"},
+				{PathOnHost: "/dev/fuse", PathInContainer: "/dev/fuse", CgroupPermissions: "rwm"},
+				{PathOnHost: "/dev/net/tun", PathInContainer: "/dev/net/tun", CgroupPermissions: "rwm"},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := toDeviceSlice(tc.pipelineConfig, tc.step)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/engine/spec/spec.go
+++ b/engine/spec/spec.go
@@ -145,6 +145,10 @@ type (
 	VolumeDevice struct {
 		Name       string `json:"name,omitempty"`
 		DevicePath string `json:"path,omitempty"`
+		// HostPath is the device path on the host (e.g. "/dev/kvm").
+		// When set, the device is mapped directly without requiring
+		// a corresponding entry in PipelineConfig.Volumes.
+		HostPath string `json:"host_path,omitempty"`
 	}
 
 	// Network that is created and attached to containers


### PR DESCRIPTION
- Add HostPath field to VolumeDevice for direct device mapping
- Fix guard condition to process devices independently of volumes
- Support both direct HostPath and legacy Name-based device lookup
- Include 9 test cases covering direct/legacy paths and edge cases

Resolves device passthrough issue where steps specifying only devices (without volumes) were silently skipped due to unresolvable volume lookup and broken guard condition.